### PR TITLE
Update tools-widget.html to enable viewing missing fields

### DIFF
--- a/ictst/widget/tools-widget.html
+++ b/ictst/widget/tools-widget.html
@@ -33,12 +33,15 @@
       "organization": {
         "position": "resume"
       },
+      "quick_description": {
+        "position": "resume"
+      },
       "website": {
         "position": "links"
       },
-      "logo": {
-        "position": "links"
-      }
+      "status": {
+        "position": "tags"
+      }  
     },
     "detail": {
       "tool_name": {
@@ -51,7 +54,7 @@
         "position": "resume"
       },
       "website": {
-        "position": "links"
+        "position": "resume"
       },
       "environmental_indicator": {
         "position": "tags"
@@ -81,13 +84,13 @@
         "position": "tags"
       },
       "license": {
-        "position": "tag"
+        "position": "tags"
       },
       "self_hostable": {
-        "position": "tag"
+        "position": "tags"
       },
       "originating_country": {
-        "position": "tag"
+        "position": "tags"
       },
       "inside_models": {
         "position": "tags"
@@ -96,7 +99,7 @@
         "position": "tags"
       },
       "ref_sources": {
-        "position": "resume"
+        "position": "links"
       }
     }
   }


### PR DESCRIPTION
In the cardview settings, correction of the "tag" value by "tags" value to enable all fields to be visible (the tag vs tags distinction doesn't apply in the cardview setting only in the fields-custome-properties.json file).  Change position of some fields and added quick desc to mini-card view (and remoced the logo for the moment)