### PR TITLE
fix: documentation tab image link

### DIFF
--- a/ictst/texts/data-dictionary.md
+++ b/ictst/texts/data-dictionary.md
@@ -2,4 +2,4 @@
 
 This page describes the data model.
 
-![An alternate text for the sample picture. The picture is is located in ictst/texts directory of the repository, but note that the url used in the link is more complex (need to have /blob/main in it) ](https://github.com/Boavizta/ict-sustainability-tools/blob/main/ictst/texts/data-model-sample-picture.excalidraw.png)
+![An alternate text for the sample picture. The picture is is located in ictst/texts directory of the repository, but note that the url used in the link is more complex](https://raw.githubusercontent.com/Boavizta/ict-sustainability-tools/refs/heads/main/ictst/texts/data-model-sample-picture.excalidraw.png)


### PR DESCRIPTION
Link to URL that works is (use raw.githubusercontent.com )

https://raw.githubusercontent.com/Boavizta/ict-sustainability-tools/refs/heads/main/ictst/texts/data-model-sample-picture.excalidraw.png